### PR TITLE
Deprecation login_headertitle Fix

### DIFF
--- a/inc/dashboard-customisation.php
+++ b/inc/dashboard-customisation.php
@@ -43,7 +43,7 @@ add_filter( 'login_headerurl', 'my_login_logo_url' );
 function my_login_logo_url_title() {
     return get_bloginfo( 'name' );
 }
-add_filter( 'login_headertitle', 'my_login_logo_url_title' );
+add_filter( 'login_headertext', 'my_login_logo_url_title' );
 function my_login_stylesheet() {
     wp_enqueue_style( 'custom-login', get_stylesheet_directory_uri() . '/css/style-login.css' );
 }


### PR DESCRIPTION
Fixes the 'Deprecated: login_headertitle is deprecated since version 5.2.0!' error on wp-login